### PR TITLE
Fix based on the latest chages from the Whirpool component 

### DIFF
--- a/components/mirage/climate.py
+++ b/components/mirage/climate.py
@@ -9,7 +9,7 @@ CODEOWNERS = ["@glmnet"]
 mirage_ns = cg.esphome_ns.namespace("mirage")
 MirageClimate = mirage_ns.class_("MirageClimate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.CLIMATE_IR_WITH_RECEIVER_SCHEMA.extend(
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema.extend(
     {
         cv.GenerateID(): cv.declare_id(MirageClimate),
     }

--- a/components/mirage/climate.py
+++ b/components/mirage/climate.py
@@ -9,13 +9,11 @@ CODEOWNERS = ["@glmnet"]
 mirage_ns = cg.esphome_ns.namespace("mirage")
 MirageClimate = mirage_ns.class_("MirageClimate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema.extend(
-    {
-        cv.GenerateID(): cv.declare_id(MirageClimate),
-    }
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(MirageClimate).extend(
+    {}
 )
 
 
 async def to_code(config):
-    var = cg.new_Pvariable(config[CONF_ID])
-    await climate_ir.register_climate_ir(var, config)
+    var = await climate_ir.new_climate_ir(config)
+    cg.add(var.set_model(config[CONF_MODEL]))

--- a/components/mirage/climate.py
+++ b/components/mirage/climate.py
@@ -16,4 +16,3 @@ CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(MirageClimate).extend
 
 async def to_code(config):
     var = await climate_ir.new_climate_ir(config)
-    cg.add(var.set_model(config[CONF_MODEL]))

--- a/components/mirage/mirage.cpp
+++ b/components/mirage/mirage.cpp
@@ -27,6 +27,7 @@ const uint8_t MIRAGE_SWING_HORIZONTAL = 0x01;
 const uint8_t MIRAGE_SWING_VERTICAL = 0x1A;
 
 const uint8_t MIRAGE_POWER_OFF = 0xC0;
+const uint8_t MIRAGE_REMOTE_POWER_OFF = 0xC2;
 
 const uint8_t MIRAGE_TEMP_OFFSET = 0x5C;
 
@@ -136,7 +137,7 @@ bool MirageClimate::on_receive(remote_base::RemoteReceiveData data) {
   const esphome::remote_base::MirageData& data_decoded = *optional_data_decoded;  // Dereference the optional to get the MirageData
   obj.dump(data_decoded);
 
-  if (data_decoded.data[5] == MIRAGE_POWER_OFF) {
+  if (data_decoded.data[5] == MIRAGE_POWER_OFF || data_decoded.data[5] == MIRAGE_REMOTE_POWER_OFF) {
       this->mode = climate::CLIMATE_MODE_OFF;
   } else {
     auto mode = data_decoded.data[4] & 0x70;


### PR DESCRIPTION
I tried the component with ESPHome version 2025.5.2, but it didn't work. No sensors/controls were showing in Home Assistant. I compared the code with the source of the [Whirlpool](https://github.com/esphome/esphome/tree/dev/esphome/components/whirlpool) component, which this one is supposed to be based on, and there were some differences. 

After making these changes to the component, it now works properly. Tested it in a Mirage v32 Inverter unit (Cool + Heat). 

Disclaimer: I'm neither a Python nor a C developer; I just made the changes based on what I saw missing from the Whirpool integration. 